### PR TITLE
Camera auth fixes

### DIFF
--- a/custom_components/badnest/api.py
+++ b/custom_components/badnest/api.py
@@ -96,6 +96,9 @@ class NestAPI():
         r = self._session.post(url=URL_JWT, headers=headers, params=params)
         self._user_id = r.json()['claims']['subject']['nestId']['id']
         self._access_token = r.json()['jwt']
+        self._session.headers.update({
+            "Authorization": f"Basic {self._access_token}",
+        })
 
     def _login_dropcam(self):
         self._session.post(
@@ -110,7 +113,6 @@ class NestAPI():
             r = self._session.get(
                 f"{CAMERA_WEBAPI_BASE}/api/cameras."
                 + "get_owned_and_member_of_with_properties",
-                headers={"Authorization": f"Basic {self._access_token}"},
             )
 
             for camera in r.json()["items"]:

--- a/custom_components/badnest/api.py
+++ b/custom_components/badnest/api.py
@@ -109,7 +109,8 @@ class NestAPI():
         try:
             r = self._session.get(
                 f"{CAMERA_WEBAPI_BASE}/api/cameras."
-                + "get_owned_and_member_of_with_properties"
+                + "get_owned_and_member_of_with_properties",
+                headers={"Authorization": f"Basic {self._access_token}"},
             )
 
             for camera in r.json()["items"]:

--- a/custom_components/badnest/api.py
+++ b/custom_components/badnest/api.py
@@ -115,7 +115,10 @@ class NestAPI():
 
             for camera in r.json()["items"]:
                 cameras.append(camera['uuid'])
-                self.device_data[camera['uuid']] = {}
+                camera['battery_voltage'] = camera["rq_battery_battery_volt"]
+                camera['ac_voltage'] = camera["rq_battery_vbridge_volt"]
+                camera['data_tier'] = camera["properties"]["streaming.data-usage-tier"]
+                self.device_data[camera['uuid']] = camera
 
             return cameras
         except requests.exceptions.RequestException as e:

--- a/custom_components/badnest/api.py
+++ b/custom_components/badnest/api.py
@@ -304,27 +304,6 @@ class NestAPI():
                         sensor_data['current_temperature']
                     self.device_data[sn]['battery_level'] = \
                         sensor_data['battery_level']
-
-            # Cameras
-            for camera in self.cameras:
-                r = self._session.get(
-                    f"{API_URL}/dropcam/api/cameras/{camera}"
-                )
-                sensor_data = r.json()[0]
-                self.device_data[camera]['name'] = \
-                    sensor_data["name"]
-                self.device_data[camera]['is_online'] = \
-                    sensor_data["is_online"]
-                self.device_data[camera]['is_streaming'] = \
-                    sensor_data["is_streaming"]
-                self.device_data[camera]['battery_voltage'] = \
-                    sensor_data["rq_battery_battery_volt"]
-                self.device_data[camera]['ac_voltage'] = \
-                    sensor_data["rq_battery_vbridge_volt"]
-                self.device_data[camera]['location'] = \
-                    sensor_data["location"]
-                self.device_data[camera]['data_tier'] = \
-                    sensor_data["properties"]["streaming.data-usage-tier"]
         except requests.exceptions.RequestException as e:
             _LOGGER.error(e)
             _LOGGER.error('Failed to update, trying again')

--- a/custom_components/badnest/api.py
+++ b/custom_components/badnest/api.py
@@ -507,7 +507,8 @@ class NestAPI():
         try:
             r = self._session.get(
                 f'{self._camera_url}/get_image?uuid={device_id}' +
-                f'&cachebuster={now}'
+                f'&cachebuster={now}',
+                headers={"cookie": f'user_token={self._access_token}'},
             )
 
             return r.content


### PR DESCRIPTION
I was getting SSL errors from the camera's endpoint. Adding authentication headers fixed it.

I then got a Forbidden response from get_image request. Adding a user_token cookie with the access token fixed this.

I don't have access to a Nest Access token to test if that works with this.