### PR TITLE
Fix misleading log message in camera.py

### DIFF
--- a/custom_components/badnest/camera.py
+++ b/custom_components/badnest/camera.py
@@ -23,7 +23,7 @@ async def async_setup_platform(hass,
     api = hass.data[DOMAIN]['api']
 
     cameras = []
-    _LOGGER.info("Adding temperature sensors")
+    _LOGGER.info("Adding cameras")
     for camera in api['cameras']:
         _LOGGER.info(f"Adding nest camera uuid: {camera}")
         cameras.append(NestCamera(camera, api))


### PR DESCRIPTION
Updating misleading log message - this file has to do with cameras, not temperature sensors.