### PR TITLE
Improve error messages when user_id is unavailable

### DIFF
--- a/custom_components/badnest/api.py
+++ b/custom_components/badnest/api.py
@@ -127,6 +127,7 @@ class NestAPI():
             return self._get_cameras()
 
     def _get_devices(self):
+        assert self._user_id, "No user_id found; check configuration"
         try:
             r = self._session.post(
                 f"{API_URL}/api/0.1/user/{self._user_id}/app_launch",
@@ -178,6 +179,7 @@ class NestAPI():
             return "Unknown"
 
     def update(self):
+        assert self._user_id, "No user_id found; check configuration"
         try:
             # To get friendly names
             r = self._session.post(


### PR DESCRIPTION
I had a configuration like this for a while and was unable to figure out why the integration was broken.

```
badnest:
    access_token: "b.12345.abcxyz"
    userid: 12345   # typo here; should be user_id
    region: us
```

The issue ended up being that I had a typo in the `user_id` field and was missing an underscore.

To make this easier to catch for the next person, this PR improves the error message when user_id is unset. Note that this can be fixed by either the presence of the `user_id` field, or I think also the newer `issue_token` + `cookie` fields. Because these requirements are too complicated to explain in a short message, I left a more generic message of user id being unavailable.