### PR TITLE
Handle when device name does not come in the wheres

### DIFF
--- a/custom_components/badnest/api.py
+++ b/custom_components/badnest/api.py
@@ -213,6 +213,9 @@ class NestAPI():
                 # Thermostats (thermostat and sensors system)
                 if bucket["object_key"].startswith(
                         f"shared.{sn}"):
+                    if 'name' in sensor_data:
+                        self.device_data[sn]['name'] = \
+                            sensor_data['name']
                     self.device_data[sn]['current_temperature'] = \
                         sensor_data["current_temperature"]
                     self.device_data[sn]['target_temperature'] = \
@@ -240,9 +243,10 @@ class NestAPI():
                 # Thermostats, pt 2
                 elif bucket["object_key"].startswith(
                         f"device.{sn}"):
-                    self.device_data[sn]['name'] = self._wheres[
-                        sensor_data['where_id']
-                    ]
+                    if 'where_id' in sensor_data:
+                        self.device_data[sn]['name'] = self._wheres[
+                            sensor_data['where_id']
+                        ]
                     # When acts as a sensor
                     if 'backplate_temperature' in sensor_data:
                         self.device_data[sn]['temperature'] = \


### PR DESCRIPTION
With my thermostat badnest would not start up, it would just fail with 
```
2020-05-08 10:37:44 ERROR (MainThread) [homeassistant.setup] Error during setup of component badnest
Traceback (most recent call last):
  File "/config/custom_components/badnest/api.py", line 244, in update
    sensor_data['where_id']
KeyError: 'where_id'
```
Looking at the code it seems to assume the device name comes in a separate "where" bucket, referenced via a _where_id_ in the _shared_ bucket...but in my case the name comes as part of the _device_ bucket and there is no _where_id_ in the _shared_ bucket.  So this modification makes it optionally pull the name from either location.