### PR TITLE
Change ClimateDevice to ClimateEntity to deal with deprecation warning

### DIFF
--- a/custom_components/badnest/climate.py
+++ b/custom_components/badnest/climate.py
@@ -2,7 +2,7 @@
 from datetime import datetime
 import logging
 
-from homeassistant.components.climate import ClimateDevice
+from homeassistant.components.climate import ClimateEntity
 from homeassistant.components.climate.const import (
     ATTR_TARGET_TEMP_HIGH,
     ATTR_TARGET_TEMP_LOW,
@@ -78,8 +78,8 @@ async def async_setup_platform(hass,
     async_add_entities(thermostats)
 
 
-class NestClimate(ClimateDevice):
-    """Representation of a Nest climate device."""
+class NestClimate(ClimateEntity):
+    """Representation of a Nest climate entity."""
 
     def __init__(self, device_id, api):
         """Initialize the thermostat."""


### PR DESCRIPTION
Fixes: #124

The following is seen with HA 0.110.0:
`WARNING (MainThread) [homeassistant.components.climate] ClimateDevice is deprecated, modify NestClimate to extend ClimateEntity`